### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,9 +348,9 @@ checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
 
 [[package]]
 name = "divan"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf174e1957cfadab3bcb040afb210ea8b7c2ffc094eb88b750be61fc601835e"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
  "cfg-if",
  "clap",
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-divan = "0.1.8"
+divan = "0.1.11"
 lockstitch = { path = ".." }
 
 [[bench]]

--- a/benchmarks/benches/benchmarks.rs
+++ b/benchmarks/benches/benchmarks.rs
@@ -7,20 +7,20 @@ use lockstitch::{Protocol, TAG_LEN};
 
 const LENS: &[usize] = &[16, 256, 1024, 16 * 1024, 1024 * 1024];
 
-#[divan::bench(consts = LENS)]
-fn hash<const LEN: usize>(bencher: divan::Bencher) {
-    bencher.with_inputs(|| vec![0u8; LEN]).counter(BytesCount::new(LEN)).bench_refs(|message| {
+#[divan::bench(args = LENS)]
+fn hash(bencher: divan::Bencher, len: usize) {
+    bencher.with_inputs(|| vec![0u8; len]).counter(BytesCount::new(len)).bench_refs(|message| {
         let mut protocol = Protocol::new("hash");
         protocol.mix("message", message);
         protocol.derive_array::<32>("digest")
     });
 }
 
-#[divan::bench(consts = LENS)]
-fn hash_writer<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn hash_writer(bencher: divan::Bencher, len: usize) {
     bencher
-        .with_inputs(|| io::repeat(0).take(LEN as u64))
-        .counter(BytesCount::new(LEN))
+        .with_inputs(|| io::repeat(0).take(len as u64))
+        .counter(BytesCount::new(len))
         .bench_values(|mut input| {
             let protocol = Protocol::new("hash");
             let mut writer = protocol.mix_writer("message", io::sink());
@@ -30,11 +30,11 @@ fn hash_writer<const LEN: usize>(bencher: divan::Bencher) {
         });
 }
 
-#[divan::bench(consts = LENS)]
-fn stream<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn stream(bencher: divan::Bencher, len: usize) {
     let key = [0u8; 32];
     let nonce = [0u8; 16];
-    bencher.with_inputs(|| vec![0u8; LEN]).counter(BytesCount::new(LEN)).bench_values(
+    bencher.with_inputs(|| vec![0u8; len]).counter(BytesCount::new(len)).bench_values(
         |mut block| {
             let mut protocol = Protocol::new("stream");
             protocol.mix("key", &key);
@@ -45,12 +45,12 @@ fn stream<const LEN: usize>(bencher: divan::Bencher) {
     );
 }
 
-#[divan::bench(consts = LENS)]
-fn aead<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn aead(bencher: divan::Bencher, len: usize) {
     let key = [0u8; 32];
     let nonce = [0u8; 16];
     let ad = [0u8; 32];
-    bencher.with_inputs(|| vec![0u8; LEN + TAG_LEN]).counter(BytesCount::new(LEN)).bench_values(
+    bencher.with_inputs(|| vec![0u8; len + TAG_LEN]).counter(BytesCount::new(len)).bench_values(
         |mut block| {
             let mut protocol = Protocol::new("aead");
             protocol.mix("key", &key);
@@ -62,10 +62,10 @@ fn aead<const LEN: usize>(bencher: divan::Bencher) {
     );
 }
 
-#[divan::bench(consts = LENS)]
-fn prf<const LEN: usize>(bencher: divan::Bencher) {
+#[divan::bench(args = LENS)]
+fn prf(bencher: divan::Bencher, len: usize) {
     let key = [0u8; 32];
-    bencher.with_inputs(|| vec![0u8; LEN]).counter(BytesCount::new(LEN)).bench_values(
+    bencher.with_inputs(|| vec![0u8; len]).counter(BytesCount::new(len)).bench_values(
         |mut block| {
             let mut protocol = Protocol::new("prf");
             protocol.mix("key", &key);


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.